### PR TITLE
Read configuration from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ When running, rambler will try to find a configuration file in the working direc
 
 Rambler now supports [HJSON](http://hjson.org/) configuration files, which is by the way retrocompatible with JSON.
 
+#### Environment Variables
+
+Alternatively, Rambler can read configuration from environment variables. The
+environment variables can override any of the confifuration file values and
+are prefixed with `RAMBLER_`.
+
+| Env Var           | Config    |
+|-------------------|-----------|
+| RAMBLER_DRIVER    | driver    |
+| RAMBLER_PROTOCOL  | protocol  |
+| RAMBLER_HOST      | host      |
+| RAMBLER_PORT      | port      |
+| RAMBLER_USER      | user      |
+| RAMBLER_PASSWORD  | password  |
+| RAMBLER_DATABASE  | database  |
+| RAMBLER_DIRECTORY | directory |
+| RAMBLER_TABLE     | table     |
+
 #### Drivers
 
 Rambler supports actually 3 drivers:

--- a/configuration.go
+++ b/configuration.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/client9/xson/hjson"
 	"github.com/imdario/mergo"
+	"github.com/kelseyhightower/envconfig"
 )
 
 // Configuration is the configuration type
@@ -25,6 +26,11 @@ func Load(filename string) (Configuration, error) {
 	}
 
 	err = hjson.Unmarshal(raw, &c)
+	if err != nil {
+		return Configuration{}, err
+	}
+
+	err = envconfig.Process("rambler", &c)
 	if err != nil {
 		return Configuration{}, err
 	}


### PR DESCRIPTION
We are using rambler in a Docker container and found it easier to read the configuration values from the environment. I'm opening this PR to see if this would be something that you think would be beneficial to pull back into the project.

Let me know if I can do anything to clean it up or add more documentation to the README. 

Thanks for creating rambler!