### PR TITLE
Use migration column as primary key

### DIFF
--- a/driver/mysql/driver.go
+++ b/driver/mysql/driver.go
@@ -52,7 +52,7 @@ func (c Conn) HasTable() (bool, error) {
 
 // CreateTable create the migration table using a MySQL-compatible syntax.
 func (c Conn) CreateTable() error {
-	_, err := c.db.Exec(fmt.Sprintf(`CREATE TABLE %s ( migration VARCHAR(255) NOT NULL ) DEFAULT CHARSET=utf8`, c.table))
+	_, err := c.db.Exec(fmt.Sprintf(`CREATE TABLE %s ( migration VARCHAR(255) NOT NULL, PRIMARY KEY(migration) ) DEFAULT CHARSET=utf8`, c.table))
 	return err
 }
 


### PR DESCRIPTION
This Pull Request modifies the MySQL driver to use the migration column as a MySQL driver. This should not have any influence on any classic MySQL installations.
But Percona XtraDB cluster don't allow DML commands on tables without primary because it prevents them to properly distribute the write operation in the cluster.
I tested this change against our XtraDB cluster and the migration runs as expected and the expected entries are created in the migrations table.