### PR TITLE
Enables use of schema in PG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant
 .goxc.local.json
-
+.idea/

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ by the way retrocompatible with JSON.
 #### Environment Variables
 
 Alternatively, Rambler can read configuration from environment variables. The
-environment variables can override any of the confifuration file values and
+environment variables can override any of the configuration file values and
 are prefixed with `RAMBLER_`.
 
 | Env Var           | Config    |
@@ -101,6 +101,12 @@ are prefixed with `RAMBLER_`.
 | RAMBLER_DATABASE  | database  |
 | RAMBLER_DIRECTORY | directory |
 | RAMBLER_TABLE     | table     |
+
+##### Environment Variables in Scripts
+If you need to externalize values, such as password hashes for default accounts,
+you can integrate environmental variable using ${var} syntax. This will match
+against environment values matched as all caps. ${sys_pass} find an environment
+variable an SYS_PASS as will ${SYS_PASS}.
 
 #### Drivers
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ are prefixed with `RAMBLER_`.
 | RAMBLER_USER      | user      |
 | RAMBLER_PASSWORD  | password  |
 | RAMBLER_DATABASE  | database  |
+| RAMBLER_SCHEMA    | schema    |
 | RAMBLER_DIRECTORY | directory |
 | RAMBLER_TABLE     | table     |
 

--- a/apply.go
+++ b/apply.go
@@ -23,7 +23,7 @@ func apply(service Servicer, all bool, logger *log.Logger) error {
 		logger.Info("initializing database")
 		err := service.Initialize()
 		if err != nil {
-			return fmt.Errorf("unable to initialize database: %s", err)
+			return fmt.Errorf("unable to initialize database: %v", err)
 		}
 	}
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -6,7 +6,7 @@ import (
 
 // Driver is the interface used by the program to initialize the database connection.
 type Driver interface {
-	New(dns, schema, table string) (Conn, error)
+	New(dns, database, schema, table string) (Conn, error)
 }
 
 var drivers = make(map[string]Driver)
@@ -26,13 +26,13 @@ func Register(name string, driver Driver) error {
 }
 
 // Get initialize a driver from the given environment
-func Get(drv, dsn, schema, table string) (Conn, error) {
+func Get(drv, dsn, database, schema, table string) (Conn, error) {
 	driver, found := drivers[drv]
 	if !found {
 		return nil, fmt.Errorf(`driver "%s" not registered`, drv)
 	}
 
-	conn, err := driver.New(dsn, schema, table)
+	conn, err := driver.New(dsn, database, schema, table)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 type MockDriver struct {
-	new func(string, string, string) (Conn, error)
+	new func(string, string, string, string) (Conn, error)
 }
 
-func (d *MockDriver) New(dsn, schema, table string) (Conn, error) {
-	return d.new(dsn, schema, table)
+func (d *MockDriver) New(dsn, database, schema, table string) (Conn, error) {
+	return d.new(dsn, database, schema, table)
 }
 
 func Test_Register_NilDriver(t *testing.T) {
@@ -52,7 +52,7 @@ func Test_Register_OK(t *testing.T) {
 func Test_Get_NotRegistered(t *testing.T) {
 	drivers = make(map[string]Driver)
 
-	_, err := Get("test", "", "", "migrations")
+	_, err := Get("test", "", "","", "migrations")
 	if err == nil {
 		t.Fail()
 	}
@@ -62,7 +62,7 @@ func Test_Get_InitializeError(t *testing.T) {
 	drivers = make(map[string]Driver)
 
 	driver := &MockDriver{}
-	driver.new = func(_, _, _ string) (Conn, error) {
+	driver.new = func(_, _, _, _ string) (Conn, error) {
 		return nil, errors.New("initialize error")
 	}
 
@@ -71,7 +71,7 @@ func Test_Get_InitializeError(t *testing.T) {
 		t.Fail()
 	}
 
-	_, err = Get("test", "", "", "migrations")
+	_, err = Get("test", "", "", "", "migrations")
 	if err == nil {
 		t.Fail()
 	}
@@ -80,7 +80,7 @@ func Test_Get_InitializeError(t *testing.T) {
 func Test_Get_OK(t *testing.T) {
 	drivers = make(map[string]Driver)
 	driver := &MockDriver{}
-	driver.new = func(_, _, _ string) (Conn, error) {
+	driver.new = func(_, _,_, _ string) (Conn, error) {
 		return nil, nil
 	}
 
@@ -89,7 +89,7 @@ func Test_Get_OK(t *testing.T) {
 		t.Fail()
 	}
 
-	_, err = Get("test", "", "", "migrations")
+	_, err = Get("test", "", "","", "migrations")
 	if err != nil {
 		t.Fail()
 	}

--- a/driver/mysql/driver.go
+++ b/driver/mysql/driver.go
@@ -15,7 +15,8 @@ func init() {
 // Driver is the type that initialize new connections.
 type Driver struct{}
 
-func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
+func (d Driver) New(dsn, database, _, table string) (driver.Conn, error) {
+	// MySQL treats database and schema as the same.
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
@@ -23,7 +24,8 @@ func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
 
 	return Conn{
 		db:     db,
-		schema: schema,
+		database: database,
+		schema: database,
 		table:  table,
 	}, nil
 }
@@ -31,6 +33,7 @@ func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
 // Conn holds a connection to a MySQL database schema.
 type Conn struct {
 	db     *sql.DB
+	database string
 	schema string
 	table  string
 }

--- a/driver/postgresql/driver.go
+++ b/driver/postgresql/driver.go
@@ -1,29 +1,41 @@
-package mysql
+package postgresql
 
 import (
 	"database/sql"
 	"fmt"
+	"github.com/elwinar/rambler/log"
 
 	"github.com/elwinar/rambler/driver"
 	_ "github.com/lib/pq" // Working with the lib/pq PostgreSQL driver here.
 )
 
+var logger  *log.Logger
+
 func init() {
 	driver.Register("postgresql", Driver{})
+	logger = log.NewLogger(func(l *log.Logger) {
+		l.PrintDebug = true
+	})
 }
+
+
 
 // Driver initialize new connections to a PostgreSQL database schema.
 type Driver struct{}
 
 // New returns a new connection.
-func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
+func (d Driver) New(dsn, database, schema, table string) (driver.Conn, error) {
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return nil, err
 	}
-
+	// Use the default schema.
+	if schema == "" {
+		schema = "public"
+	}
 	c := &Conn{
 		db:     db,
+		database: database,
 		schema: schema,
 		table:  table,
 	}
@@ -31,17 +43,30 @@ func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
 	return c, nil
 }
 
+func (c*  Conn) qualifiedTable() string {
+	if c.schema == "" {
+		return c.table
+	}
+	return c.schema + "." + c.table
+}
+
 // Connection holds a database connection.
 type Conn struct {
 	db     *sql.DB
+	database string
 	schema string
 	table  string
 }
 
 // HasTable check if the schema has the migration table.
 func (c *Conn) HasTable() (bool, error) {
+	logger.Debug(fmt.Sprintf("Loading against: %s", c))
+
 	var name string
-	err := c.db.QueryRow(`SELECT table_name FROM information_schema.tables WHERE table_catalog = $1 AND table_name = $2`, c.schema, c.table).Scan(&name)
+
+	err := c.db.QueryRow(
+		`SELECT table_name FROM information_schema.tables WHERE table_catalog = $1 AND table_schema = $2 AND table_name = $3`,
+		c.database, c.schema, c.table).Scan(&name)
 	if err != nil && err != sql.ErrNoRows {
 		return false, err
 	}
@@ -53,13 +78,17 @@ func (c *Conn) HasTable() (bool, error) {
 
 // CreateTable create the migration table using a PostgreSQL-compatible syntax.
 func (c *Conn) CreateTable() error {
-	_, err := c.db.Exec(fmt.Sprintf(`CREATE TABLE %s ( migration VARCHAR(255) NOT NULL );`, c.table))
+	_, err := c.db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s ( migration VARCHAR(255) NOT NULL );`, c.qualifiedTable()))
+	if err != nil {
+		err = fmt.Errorf("failed to create table '%s'. %s", c.table, err)
+	}
 	return err
 }
 
 // GetApplied returns the list of applied migrations.
 func (c *Conn) GetApplied() ([]string, error) {
-	rows, err := c.db.Query(fmt.Sprintf(`SELECT migration FROM %s ORDER BY migration ASC`, c.table))
+
+	rows, err := c.db.Query(fmt.Sprintf(`SELECT migration FROM %s ORDER BY migration ASC`, c.qualifiedTable()))
 	if err != nil {
 		return nil, err
 	}
@@ -81,13 +110,13 @@ func (c *Conn) GetApplied() ([]string, error) {
 
 // AddApplied records a migration as applied.
 func (c *Conn) AddApplied(migration string) error {
-	_, err := c.db.Exec(fmt.Sprintf(`INSERT INTO %s (migration) VALUES ($1)`, c.table), migration)
+	_, err := c.db.Exec(fmt.Sprintf(`INSERT INTO %s (migration) VALUES ($1)`, c.qualifiedTable()), migration)
 	return err
 }
 
 // RemoveApplied records a migration as reversed.
 func (c *Conn) RemoveApplied(migration string) error {
-	_, err := c.db.Exec(fmt.Sprintf(`DELETE FROM %s WHERE migration = $1`, c.table), migration)
+	_, err := c.db.Exec(fmt.Sprintf(`DELETE FROM %s WHERE migration = $1`, c.qualifiedTable()), migration)
 	return err
 }
 
@@ -95,4 +124,8 @@ func (c *Conn) RemoveApplied(migration string) error {
 func (c *Conn) Execute(query string) error {
 	_, err := c.db.Exec(query)
 	return err
+}
+
+func (c *Conn) String() string {
+	return fmt.Sprintf("database: '%s', schema: '%s', table: '%s'\n", c.database, c.schema, c.table)
 }

--- a/driver/sqlite/driver.go
+++ b/driver/sqlite/driver.go
@@ -14,23 +14,23 @@ func init() {
 
 type Driver struct{}
 
-func (d Driver) New(dsn, schema, table string) (driver.Conn, error) {
+func (d Driver) New(dsn, database, _, table string) (driver.Conn, error) {
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, err
 	}
 
 	return Conn{
-		db:     db,
-		schema: schema,
-		table:  table,
+		db:       db,
+		database: database,
+		table:    table,
 	}, nil
 }
 
 type Conn struct {
-	db     *sql.DB
-	schema string
-	table  string
+	db       *sql.DB
+	database string
+	table    string
 }
 
 func (c Conn) HasTable() (bool, error) {

--- a/environment.go
+++ b/environment.go
@@ -14,6 +14,7 @@ type Environment struct {
 	User      string `json:"user"`
 	Password  string `json:"password"`
 	Database  string `json:"database"`
+	Schema    string `json:"schema"`
 	Directory string `json:"directory"`
 	Table     string `json:"table"`
 }

--- a/envreplacer.go
+++ b/envreplacer.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+
+var reg *regexp.Regexp
+
+func init() {
+	reg2, err := regexp.Compile(`\$\{(.+?)\}`)
+	if err != nil {
+		panic("couldn't compile reg ex")
+	}
+	reg = reg2
+}
+
+func findEntries(statement string) []string {
+	return reg.FindAllString(statement, -1)
+}
+
+
+func findEnvVal(toReplace string) (string, error) {
+	key := strings.TrimSuffix(toReplace, "}")
+	key = strings.TrimPrefix(key, "${")
+	value := os.Getenv(strings.ToUpper(key))
+	if value == "" {
+		return "", fmt.Errorf("could not find env value for %s", toReplace)
+	}
+
+	return value, nil
+}
+
+func replace(statement string) (string, error) {
+	r := findEntries(statement)
+	if len(r) == 0 {
+		return statement, nil
+	}
+
+	var replacements []string
+	for _, tr := range r {
+		val, err := findEnvVal(tr)
+		if err != nil {
+			return "", err
+		}
+
+		replacements = append(replacements, val)
+	}
+
+	for i, val := range replacements {
+		key := r[i]
+		statement = strings.Replace(statement, key, val, 1)
+	}
+	return statement, nil
+}

--- a/envreplacer.go
+++ b/envreplacer.go
@@ -27,6 +27,7 @@ func findEnvVal(toReplace string) (string, error) {
 	key := strings.TrimSuffix(toReplace, "}")
 	key = strings.TrimPrefix(key, "${")
 	value := os.Getenv(strings.ToUpper(key))
+
 	if value == "" {
 		return "", fmt.Errorf("could not find env value for %s", toReplace)
 	}

--- a/envreplacer_test.go
+++ b/envreplacer_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFindEntries(t *testing.T) {
+	{
+		known := "INSERT INTO ${schema}.accounts (id, password) VALUES (2, '${pwd}')"
+		found := findEntries(known)
+		if len(found) != 2 {
+			t.Error("Did not find entries")
+			return
+		}
+	}
+
+	{
+		known := "INSERT INTO accounts (id, password) VALUES (2, 'iscleartext')"
+		found := findEntries(known)
+		if len(found) != 0 {
+			t.Error("Did not find entries")
+			return
+		}
+	}
+}
+
+func TestFindEnv(t *testing.T) {
+	{
+		os.Setenv("MYPASSWORD2", "alsocleartext")
+		_, err := findEnvVal("${myPassword}")
+		if err == nil {
+			t.Error("should have failed")
+		}
+	}
+	{
+		os.Setenv("MYPASSWORD", "alsocleartext")
+		_, err := findEnvVal("${myPassword}")
+		if err != nil {
+			t.Error("should have found")
+		}
+	}
+}
+
+func TestReplace(t *testing.T) {
+	{
+		os.Setenv("MYPASSWORD", "alsocleartext")
+		os.Setenv("SCHEMA", "example")
+		statement :=
+			`INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');`
+		rs, err := replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+
+		expected :=
+			`INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');`
+		if expected != rs {
+			t.Errorf("expected: '%s' does not match '%s'", expected, rs)
+		}
+
+
+		statement =
+			`INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');
+INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');`
+		rs, err = replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+		expected2 := `INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');
+INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');`
+		if expected2 != rs {
+			t.Errorf("expected: '%s' does not match '%s'", expected2, rs)
+		}
+
+		statement = "There is nothing to replace. Move along now."
+		rs, err = replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+		if statement != rs {
+			t.Errorf("Expected equal. '%s' and '%s' ", statement, rs)
+		}
+	}
+}

--- a/service.go
+++ b/service.go
@@ -113,7 +113,11 @@ func (s Service) Apply(migration *Migration) error {
 	}
 
 	for _, statement := range migration.Up() {
-		err := s.conn.Execute(statement)
+		newStatement, err := replace(statement)
+		if err != nil {
+			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
+		}
+		err = s.conn.Execute(newStatement)
 		if err != nil {
 			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
 		}
@@ -135,7 +139,11 @@ func (s Service) Reverse(migration *Migration) error {
 	}
 
 	for _, statement := range migration.Down() {
-		err := s.conn.Execute(statement)
+		newStatement, err := replace(statement)
+		if err != nil {
+			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
+		}
+		err = s.conn.Execute(newStatement)
 		if err != nil {
 			return fmt.Errorf("unable to reverse migration %s: %s\n%s", migration.Name, err, statement)
 		}

--- a/service.go
+++ b/service.go
@@ -36,7 +36,7 @@ func NewService(env Environment) (*Service, error) {
 		return nil, fmt.Errorf("%s isn't a directory", env.Directory)
 	}
 
-	conn, err := driver.Get(env.Driver, env.DSN(), env.Database, env.Table)
+	conn, err := driver.Get(env.Driver, env.DSN(), env.Database, env.Schema, env.Table)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize driver: %s", err.Error())
 	}


### PR DESCRIPTION
In PG there is a difference between databases and schemas. Rambler works fine as long as the user is creating in the default schema "public". This pull request enables differentiating between database and schemas. 

Unfortunately I'm new to Github pull requests. This change includes the environment variable integration feature as well.