### PR TITLE
Features/init scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant
 .goxc.local.json
-
+.idea/

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ by the way retrocompatible with JSON.
 #### Environment Variables
 
 Alternatively, Rambler can read configuration from environment variables. The
-environment variables can override any of the confifuration file values and
+environment variables can override any of the configuration file values and
 are prefixed with `RAMBLER_`.
 
 | Env Var           | Config    |
@@ -101,6 +101,12 @@ are prefixed with `RAMBLER_`.
 | RAMBLER_DATABASE  | database  |
 | RAMBLER_DIRECTORY | directory |
 | RAMBLER_TABLE     | table     |
+
+##### Environment Variables in Scripts
+If you need to externalize values, such as password hashes for default accounts,
+you can integrate environmental variable using ${var} syntax. This will match
+against environment values matched as all caps. ${sys_pass} find an environment
+variable an SYS_PASS as will ${SYS_PASS}.
 
 #### Drivers
 

--- a/envreplacer.go
+++ b/envreplacer.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+
+var reg *regexp.Regexp
+
+func init() {
+	reg2, err := regexp.Compile(`\$\{(.+?)\}`)
+	if err != nil {
+		panic("couldn't compile reg ex")
+	}
+	reg = reg2
+}
+
+func findEntries(statement string) []string {
+	return reg.FindAllString(statement, -1)
+}
+
+
+func findEnvVal(toReplace string) (string, error) {
+	key := strings.TrimSuffix(toReplace, "}")
+	key = strings.TrimPrefix(key, "${")
+	value := os.Getenv(strings.ToUpper(key))
+	if value == "" {
+		return "", fmt.Errorf("could not find env value for %s", toReplace)
+	}
+
+	return value, nil
+}
+
+func replace(statement string) (string, error) {
+	r := findEntries(statement)
+	if len(r) == 0 {
+		return statement, nil
+	}
+
+	var replacements []string
+	for _, tr := range r {
+		val, err := findEnvVal(tr)
+		if err != nil {
+			return "", err
+		}
+
+		replacements = append(replacements, val)
+	}
+
+	for i, val := range replacements {
+		key := r[i]
+		statement = strings.Replace(statement, key, val, 1)
+	}
+	return statement, nil
+}

--- a/envreplacer.go
+++ b/envreplacer.go
@@ -27,6 +27,7 @@ func findEnvVal(toReplace string) (string, error) {
 	key := strings.TrimSuffix(toReplace, "}")
 	key = strings.TrimPrefix(key, "${")
 	value := os.Getenv(strings.ToUpper(key))
+
 	if value == "" {
 		return "", fmt.Errorf("could not find env value for %s", toReplace)
 	}

--- a/envreplacer_test.go
+++ b/envreplacer_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFindEntries(t *testing.T) {
+	{
+		known := "INSERT INTO ${schema}.accounts (id, password) VALUES (2, '${pwd}')"
+		found := findEntries(known)
+		if len(found) != 2 {
+			t.Error("Did not find entries")
+			return
+		}
+	}
+
+	{
+		known := "INSERT INTO accounts (id, password) VALUES (2, 'iscleartext')"
+		found := findEntries(known)
+		if len(found) != 0 {
+			t.Error("Did not find entries")
+			return
+		}
+	}
+}
+
+func TestFindEnv(t *testing.T) {
+	{
+		os.Setenv("MYPASSWORD2", "alsocleartext")
+		_, err := findEnvVal("${myPassword}")
+		if err == nil {
+			t.Error("should have failed")
+		}
+	}
+	{
+		os.Setenv("MYPASSWORD", "alsocleartext")
+		_, err := findEnvVal("${myPassword}")
+		if err != nil {
+			t.Error("should have found")
+		}
+	}
+}
+
+func TestReplace(t *testing.T) {
+	{
+		os.Setenv("MYPASSWORD", "alsocleartext")
+		os.Setenv("SCHEMA", "example")
+		statement :=
+			`INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');`
+		rs, err := replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+
+		expected :=
+			`INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');`
+		if expected != rs {
+			t.Errorf("expected: '%s' does not match '%s'", expected, rs)
+		}
+
+
+		statement =
+			`INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');
+INSERT INTO ${schema}.profile (id, password) VALUES (2, '${mypassword}');`
+		rs, err = replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+		expected2 := `INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');
+INSERT INTO example.profile (id, password) VALUES (2, 'alsocleartext');`
+		if expected2 != rs {
+			t.Errorf("expected: '%s' does not match '%s'", expected2, rs)
+		}
+
+		statement = "There is nothing to replace. Move along now."
+		rs, err = replace(statement)
+		if err != nil {
+			t.Error("Failed to replace ", err)
+		}
+		if statement != rs {
+			t.Errorf("Expected equal. '%s' and '%s' ", statement, rs)
+		}
+	}
+}

--- a/migration.go
+++ b/migration.go
@@ -33,6 +33,12 @@ func NewMigration(path string) (*Migration, error) {
 	return m, nil
 }
 
+// IsPreinit indicates the migration should run before the official tracking.
+// Pre-initialization files have the standard name ending in '_pre.sql'.
+func(m Migration) IsPreinit() bool {
+	return strings.HasSuffix(m.Name, "_pre.sql")
+}
+
 // Scan retrieve all sections of the file with the given section marker.
 func (m Migration) scan(section string) []string {
 	var scanner = bufio.NewScanner(m.reader)

--- a/service.go
+++ b/service.go
@@ -113,7 +113,11 @@ func (s Service) Apply(migration *Migration) error {
 	}
 
 	for _, statement := range migration.Up() {
-		err := s.conn.Execute(statement)
+		newStatement, err := replace(statement)
+		if err != nil {
+			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
+		}
+		err = s.conn.Execute(newStatement)
 		if err != nil {
 			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
 		}
@@ -135,7 +139,11 @@ func (s Service) Reverse(migration *Migration) error {
 	}
 
 	for _, statement := range migration.Down() {
-		err := s.conn.Execute(statement)
+		newStatement, err := replace(statement)
+		if err != nil {
+			return fmt.Errorf("unable to apply migration %s: %s\n%s", migration.Name, err, statement)
+		}
+		err = s.conn.Execute(newStatement)
 		if err != nil {
 			return fmt.Errorf("unable to reverse migration %s: %s\n%s", migration.Name, err, statement)
 		}

--- a/service.go
+++ b/service.go
@@ -123,9 +123,11 @@ func (s Service) Apply(migration *Migration) error {
 		}
 	}
 
-	err := s.conn.AddApplied(migration.Name)
-	if err != nil {
-		return fmt.Errorf("unable to mark migration %s as applied: %s", migration.Name, err)
+	if !migration.IsPreinit() {
+		err := s.conn.AddApplied(migration.Name)
+		if err != nil {
+			return fmt.Errorf("unable to mark migration %s as applied: %s", migration.Name, err)
+		}
 	}
 
 	return nil
@@ -149,10 +151,11 @@ func (s Service) Reverse(migration *Migration) error {
 		}
 	}
 
-	err := s.conn.RemoveApplied(migration.Name)
-	if err != nil {
-		return fmt.Errorf("unable to mark migration %s as not applied: %s", migration.Name, err)
+	if !migration.IsPreinit() {
+		err := s.conn.RemoveApplied(migration.Name)
+		if err != nil {
+			return fmt.Errorf("unable to mark migration %s as not applied: %s", migration.Name, err)
+		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
Adds the ability to run scripts that are not tracked by the migration system. My specific use case is creating the schema before executing the migration. I don't want to have the migration table created in the public schema.

Like the schema PR, this includes the PR for adding environment variable support.