### PR TITLE
Add role support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-targets="windows/amd64,windows/386,darwin/amd64,darwin/386,linux/amd64,linux/386"
+targets="windows/amd64,windows/386,darwin/arm64,darwin/amd64,darwin/386,linux/amd64,linux/386"
 pkg="github.com/elwinar/rambler"
 version=$(shell git describe --tags)
 ldflags="-X main.VERSION=${version}"

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -40,6 +40,7 @@ type Config struct {
 	Host     string `json:"host"`
 	Port     uint64 `json:"port"`
 	User     string `json:"user"`
+	Role     string `json:"role"` // For PostgreSQL
 	Password string `json:"password"`
 	Database string `json:"database"`
 	Schema   string `json:"schema"` // For PostgreSQL

--- a/driver/postgresql/driver.go
+++ b/driver/postgresql/driver.go
@@ -32,6 +32,12 @@ func (d Driver) New(config driver.Config) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.Role != "" {
+		_, err := db.Exec(fmt.Sprintf("SET ROLE '%s';", config.Role))
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	c := &Conn{
 		db:      db,


### PR DESCRIPTION
In my clients database setup we need to be able to make the migrations using a specific role. I added support for setting a role in the `rambler.json`

Plus I added a target for cross-compiling to only apple silicon. That was only a shorthand for me so I can also remove it.