### PR TITLE
Handle large number of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .goxc.local.json
 
 *.iml
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 .goxc.local.json
 
+*.iml

--- a/migration_test.go
+++ b/migration_test.go
@@ -22,6 +22,7 @@ func TestNewMigration(t *testing.T) {
 			migration: &Migration{
 				Name:   "1_foo.sql",
 				reader: nil,
+				path: "testdata/1_foo.sql",
 			},
 			err: false,
 		},

--- a/service_test.go
+++ b/service_test.go
@@ -73,21 +73,21 @@ func TestServiceAvailable(t *testing.T) {
 		{
 			directory: "testdata/one",
 			migrations: []*Migration{
-				{Name: "1_one.sql"},
+				{Name: "1_one.sql", path: "testdata/one/1_one.sql"},
 			},
 		},
 		{
 			directory: "testdata/two",
 			migrations: []*Migration{
-				{Name: "1_one.sql"},
-				{Name: "2_two.sql"},
+				{Name: "1_one.sql", path: "testdata/two/1_one.sql"},
+				{Name: "2_two.sql", path: "testdata/two/2_two.sql"},
 			},
 		},
 		{
 			directory: "testdata/others",
 			migrations: []*Migration{
-				{Name: "1_one.sql"},
-				{Name: "2_two.sql"},
+				{Name: "1_one.sql", path: "testdata/others/1_one.sql"},
+				{Name: "2_two.sql", path: "testdata/others/2_two.sql"},
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestServiceApplied(t *testing.T) {
 				"1_one.sql",
 			},
 			migrations: []*Migration{
-				{Name: "1_one.sql"},
+				{Name: "1_one.sql", path: "testdata/one/1_one.sql"},
 			},
 		},
 		{
@@ -156,8 +156,8 @@ func TestServiceApplied(t *testing.T) {
 				"2_two.sql",
 			},
 			migrations: []*Migration{
-				{Name: "1_one.sql"},
-				{Name: "2_two.sql"},
+				{Name: "1_one.sql", path: "testdata/two/1_one.sql"},
+				{Name: "2_two.sql", path: "testdata/two/2_two.sql"},
 			},
 		},
 	}


### PR DESCRIPTION
Large numbers of migrations lead to a message like

**unable to retrieve applied migrations: unable to open file referencedata/sql/1650930505164-eq_rates_latlong_2decimals_v2-eq_rates_latlong_2decimals-219.sql: open referencedata/sql/1650930505164-eq_rates_latlong_2decimals_v2-eq_rates_latlong_2decimals-219.sql: too many open files**

Our project has 6249 migrations. This fix allows such projects to work by limiting the number of active file descriptors opened. I was able to successfully run the apply operation on the 6249 without issue.

The patch reduces the performance on large runs (sample size my project) by approximately 27%. The average duration to run the migrations with the patch is 249 seconds. The average duration to run the present release of elwinar/rambler is 194 seconds, but can't be run a second time due to file descriptor exhaustion.