### PR TITLE
Switch to techknowlogic/xgo, add linux/arm64 build target, implement github workflows, fix go.mod go version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+  release:
+    needs: [test]
+    runs-on: ubuntu-latest
+    name: Compile & archive release binaries
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Cache xgo-cache
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.xgo-cache
+        key: xgo-cache
+    - name: Install techknowlogick/xgo
+      run: go install src.techknowlogick.com/xgo@v1.8.0+1.23.2
+    - uses: docker/setup-buildx-action@v3
+    - name: Build rambler
+      run: PATH=/home/runner/.go/bin:$PATH make release
+    - name: Archive releases
+      uses: actions/upload-artifact@v4
+      with:
+        name: release
+        path: release/github.com/elwinar
+        retention-days: 90
+        if-no-files-found: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: ['*']
+    tags: ['!v*']
+  workflow_call: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Test
+      run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 *.iml
 .idea/
+/release

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-targets="windows/amd64,windows/386,darwin/arm64,darwin/amd64,darwin/386,linux/amd64,linux/386"
+targets="windows/amd64,windows/386,darwin/arm64,darwin/amd64,darwin/386,linux/amd64,linux/arm64,linux/386"
 pkg="github.com/elwinar/rambler"
 version=$(shell git describe --tags)
 ldflags="-X main.VERSION=${version}"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ help: ## Get help
 
 .PHONY: release
 release: ## Build the release files
-	xgo --dest release --targets=$(targets) --ldflags=$(ldflags) $(pkg)
+	mkdir -p release/github.com/elwinar
+	xgo --dest release --targets=$(targets) --ldflags=$(ldflags) .
 	docker-compose run -w /src main sh -c 'apk add build-base && go build -o release/rambler-alpine-amd64 --ldflags=${ldflags}'
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ help: ## Get help
 release: ## Build the release files
 	mkdir -p release/github.com/elwinar
 	xgo --dest release --targets=$(targets) --ldflags=$(ldflags) .
-	docker-compose run -w /src main sh -c 'apk add build-base && go build -o release/rambler-alpine-amd64 --ldflags=${ldflags}'
+	docker buildx build --output type=tar --build-arg VERSION=${version} --platform linux/amd64 --file build.Dockerfile . | tar -xO rambler >release/github.com/elwinar/rambler-alpine-amd64
+	docker buildx build --output type=tar --build-arg VERSION=${version} --platform linux/arm64 --file build.Dockerfile . | tar -xO rambler >release/github.com/elwinar/rambler-alpine-arm64
+	chmod +x release/github.com/elwinar/rambler-alpine-amd64 release/github.com/elwinar/rambler-alpine-arm64
 
 .PHONY: test
 test: ## Test the project

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.21
+ARG TARGETARCH
+ARG VERSION
+COPY . /go/src/github.com/elwinar/rambler
+WORKDIR /go/src/github.com/elwinar/rambler
+RUN go get ./...
+RUN go build -ldflags="-X main.VERSION=${VERSION} -s -linkmode external -extldflags -static -w"
+
+FROM scratch
+COPY --from=0 /go/src/github.com/elwinar/rambler/rambler /

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elwinar/rambler
 
-go 1.18
+go 1.21
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
So this initially started with just trying to get an arm64 binary. But I couldn't get [karalabe/xgo](https://github.com/karalabe/xgo) to work, so I followed the advice by @stoft and switched to [techknowlogic/xgo](https://github.com/techknowlogick/xgo) and that works like a charm! (with go v1.22)

And then I just got carried away and added some GitHub actions as well, so now you have automatic testing and release building with caching to boot :-)

However, the `slices` package [that you are using in `service.go`](https://github.com/elwinar/rambler/blob/0ebb15b1017ebd4b0f8003f7b22c73ba55dc6a7d/service.go#L8) doesn't exist in go v1.18, so I had to bump the required version in `go.mod` to v1.21.

~~I also remove the docker-compose call in the Makefile, it seemed to be a leftover from when you did containerized builds.~~

Anyways, this fixes #53.

EDIT: I found out what the docker-compose call was for :man_facepalming: alpine/arm64 now also works